### PR TITLE
Filters: removed string type hints from replace filter

### DIFF
--- a/src/Latte/Runtime/Filters.php
+++ b/src/Latte/Runtime/Filters.php
@@ -432,8 +432,10 @@ class Filters
 
 	/**
 	 * Performs a search and replace.
+	 * @param string|array $search
+	 * @param string|array $replacement
 	 */
-	public static function replace(FilterInfo $info, $subject, string $search, string $replacement = ''): string
+	public static function replace(FilterInfo $info, $subject, $search, $replacement = ''): string
 	{
 		return str_replace($search, $replacement, (string) $subject);
 	}


### PR DESCRIPTION
A long time ago it was possible to use the replace filter like this:
`{$var|replace:[' ','+']:['','00']}`

Today it ends up like this:
`Argument 3 passed to Latte\Runtime\Filters::replace() must be of the type string, array given`

Is it possible to avoid this BC break?